### PR TITLE
Improve readme for gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,25 @@
+### Maven ###
 dependency-reduced-pom.xml
-.classpath
-.settings
-.project
 /target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ buildscript {
    }
 }
 
+apply plugin: "info.solidsoft.pitest"
+
 pitest {
     pitestVersion = "1.2.5"
 }

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ apply plugin: "info.solidsoft.pitest"
 
 pitest {
     pitestVersion = "1.2.5"
+    targetClasses = ['our.base.package.*']  // by default "${project.group}.*"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ pitest {
     targetClasses = ['our.base.package.*']  // by default "${project.group}.*"
 }
 ```
+See [gradle-pitest-plugin documentation](http://gradle-pitest-plugin.solidsoft.info/) for more configuration options.
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ buildscript {
    }
    configurations.maybeCreate("pitest")
    dependencies {
-       classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.1.11'
+       classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.2.4'
        pitest 'org.pitest:pitest-junit5-plugin:0.2'
    }
 }


### PR DESCRIPTION
Hello,

This PR improves Gradle configuration to work "out of the box" if you just copy-paste the code snippet from readme.
Main changes: the mandatory `apply plugin: "info.solidsoft.pitest"` was missing, and the `gradle-pitest-plugin` version has been updated to the latest version.

Thank you for your hard work on pitest!
