### PR TITLE
[WIP] Handle test templates

### DIFF
--- a/src/test/java/org/pitest/junit5/repository/TestClassWithCustomTestTemplateAnnotation.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithCustomTestTemplateAnnotation.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Tobias Stadler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+package org.pitest.junit5.repository;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.stream.Stream;
+
+/**
+ * @author Tobias Stadler
+ */
+public class TestClassWithCustomTestTemplateAnnotation {
+
+    @MyTestTemplate
+    public void testTemplate() {
+    }
+
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @TestTemplate
+    @ExtendWith(TestClassWithCustomTestTemplateAnnotation.ContextProvider.class)
+    public @interface MyTestTemplate { }
+
+    public static class ContextProvider implements TestTemplateInvocationContextProvider {
+        @Override
+        public boolean supportsTestTemplate(ExtensionContext extensionContext) {
+            return true;
+        }
+
+        @Override
+        public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+            ExtensionContext extensionContext) {
+            return Stream.of(new TestTemplateInvocationContext() {
+                @Override
+                public String getDisplayName(int invocationIndex) {
+                    return "dynamic test";
+                }
+            });
+        }
+    }
+}

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithTestTemplateAnnotation.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithTestTemplateAnnotation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Tobias Stadler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+package org.pitest.junit5.repository;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+import java.util.stream.Stream;
+
+/**
+ * @author Tobias Stadler
+ */
+@ExtendWith(TestClassWithTestTemplateAnnotation.ContextProvider.class)
+public class TestClassWithTestTemplateAnnotation {
+
+    @TestTemplate
+    public void testTemplate() {
+    }
+
+    public static class ContextProvider implements TestTemplateInvocationContextProvider {
+        @Override
+        public boolean supportsTestTemplate(ExtensionContext extensionContext) {
+            return true;
+        }
+
+        @Override
+        public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+            ExtensionContext extensionContext) {
+            return Stream.of(new TestTemplateInvocationContext() {
+                @Override
+                public String getDisplayName(int invocationIndex) {
+                    return "dynamic test";
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
I realized that classes that contains only `@TestTemplate` annotations (like [parameterized tests](http://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests)) are not detected as test classes.

I fixed the issue for methods annotated with `@TestTemplate` directly (first commit).

But JUnit 5 also allow custom annotations. Parameterized tests are written that way. It means that I can create a annotation that is annotated by `@TestTemplate`. Because of that, I need to find all annotations of the class *and* look at their class to get their annotation to check if there is a `@TestTemplate` in it.

The bad new is, looking at the class `ClassInfo` of PiTest, I see no method allowing me to do that. Do you think I should  add a method to `ClassInfo` that allow us to do that ? Any other idea ?

Thanks