### PR TITLE
update readme Gradle configuration for pitest 1.3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Adds support to pitest for JUnit 5 and the Jupiter api.
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.pitest/pitest-junit5-plugin/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/org.pitest/pitest-junit5-plugin)
 
-* 0.3 requires pitest 1.30 or above
+* 0.3 requires pitest 1.3.0 or above
 * 0.2 requires pitest 1.2.5 
 
 ## Usage
@@ -47,15 +47,16 @@ buildscript {
    }
    configurations.maybeCreate("pitest")
    dependencies {
-       classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.2.4'
-       pitest 'org.pitest:pitest-junit5-plugin:0.2'
+       classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.3.0'
+       pitest 'org.pitest:pitest-junit5-plugin:0.3'
    }
 }
 
 apply plugin: "info.solidsoft.pitest"
 
 pitest {
-    pitestVersion = "1.2.5"
+    pitestVersion = "1.3.0"
+    testPlugin = "junit5"
     targetClasses = ['our.base.package.*']  // by default "${project.group}.*"
 }
 ```


### PR DESCRIPTION
Hello,

Now that https://github.com/szpak/gradle-pitest-plugin/issues/76 has been resolved, it is possible to use Pitest 1.3.x with Gradle.
This PR updates versions in README Gradle configuration, and add `testPlugin = "junit5"` configuration key which is now necessary to detect JUnit 5 tests.

Thanks!
