### PR TITLE
Update dependencies for Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,11 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<assertj.version>3.6.2</assertj.version>
+		<assertj.version>3.11.1</assertj.version>
 		<junit.platform.version>1.3.1</junit.platform.version>
 		<junit.version>5.3.1</junit.version>
 		<mockito.version>2.7.6</mockito.version>
-		<pitest.version>1.4.0</pitest.version>
+		<pitest.version>1.4.3</pitest.version>
 	</properties>
 
 	<scm>
@@ -125,9 +125,16 @@
 	<build>
 		<plugins>
 			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
+				<configuration>
+					<showWarnings>true</showWarnings>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.0</version>
+				<version>2.22.1</version>
 				<configuration>
 					<excludes>
 						<exclude>**/TestClass*</exclude>
@@ -137,7 +144,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.9</version>
+				<version>0.8.2</version>
 				<executions>
 					<execution>
 						<goals>
@@ -150,7 +157,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.4.3</version>
+				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -170,7 +177,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.0.2</version>
+				<version>3.1.0</version>
 				<configuration>
 					<archive>
 						<manifest>
@@ -202,7 +209,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.0.0-M1</version>
+				<version>3.0.1</version>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Update JaCoCo, Pitest and Maven Compiler Plugin for Java 11
compatibility, and some other dependencies along the way.