### PR TITLE
#13 treat aborted tests as successes

### DIFF
--- a/src/main/java/org/pitest/junit5/JUnit5TestUnit.java
+++ b/src/main/java/org/pitest/junit5/JUnit5TestUnit.java
@@ -78,7 +78,11 @@ public class JUnit5TestUnit extends AbstractTestUnit {
                         if (testSource instanceof MethodSource) {
                             Optional<Throwable> throwable = testExecutionResult.getThrowable();
 
-                            if (throwable.isPresent()) {
+                            if (TestExecutionResult.Status.ABORTED == testExecutionResult.getStatus()) {
+                                // abort treated as success
+                                // see: https://junit.org/junit5/docs/5.0.0/api/org/junit/jupiter/api/Assumptions.html
+                                resultCollector.notifyEnd(new Description(testIdentifier.getDisplayName(), testClass));
+                            } else if (throwable.isPresent()) {
                                 resultCollector.notifyEnd(new Description(testIdentifier.getDisplayName(), testClass), throwable.get());
                             } else {
                                 resultCollector.notifyEnd(new Description(testIdentifier.getDisplayName(), testClass));

--- a/src/test/java/org/pitest/junit5/JUnit5TestUnitTest.java
+++ b/src/test/java/org/pitest/junit5/JUnit5TestUnitTest.java
@@ -18,8 +18,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+import org.pitest.junit5.repository.TestClassWithAbortingTest;
+import org.pitest.junit5.repository.TestClassWithFailingTest;
 import org.pitest.junit5.repository.TestClassWithInheritedTestMethod;
 import org.pitest.junit5.repository.TestClassWithNestedAnnotationAndNestedTestAnnotation;
 import org.pitest.junit5.repository.TestClassWithNestedAnnotationAndNestedTestFactoryAnnotation;
@@ -104,6 +107,26 @@ public class JUnit5TestUnitTest {
         assertThat(resultCollector.getStarted()).hasSize(1);
         assertThat(resultCollector.getEnded()).hasSize(1);
     }
+
+    @Test
+    public void testTestClassWithFailingTest() {
+        TestResultCollector resultCollector = findTestsIn(TestClassWithFailingTest.class);
+
+        assertThat(resultCollector.getSkipped()).isEmpty();
+        assertThat(resultCollector.getStarted()).hasSize(1);
+        assertThat(resultCollector.getEnded()).hasSize(1);
+        assertThat(resultCollector.getFailure()).isPresent();
+    }
+
+    @Test
+    public void testTestClassWithAbortingTest() {
+        TestResultCollector resultCollector = findTestsIn(TestClassWithAbortingTest.class);
+
+        assertThat(resultCollector.getSkipped()).isEmpty();
+        assertThat(resultCollector.getStarted()).hasSize(1);
+        assertThat(resultCollector.getEnded()).hasSize(1);
+        assertThat(resultCollector.getFailure()).isEmpty();
+    }
     
     private TestResultCollector findTestsIn(Class<?> clazz) {
       TestResultCollector resultCollector = new TestResultCollector();
@@ -118,9 +141,11 @@ public class JUnit5TestUnitTest {
       private final List<Description> skipped = new ArrayList<>();
       private final List<Description> started = new ArrayList<>();
       private final List<Description> ended = new ArrayList<>();
+      private volatile Throwable failure;
 
       @Override
       public void notifyEnd(Description description, Throwable t) {
+          this.failure = t;
           notifyEnd(description);
       }
 
@@ -154,6 +179,10 @@ public class JUnit5TestUnitTest {
 
       public List<Description> getEnded() {
           return ended;
+      }
+
+      public Optional<Throwable> getFailure() {
+          return Optional.ofNullable(failure);
       }
 
   }

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithAbortingTest.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithAbortingTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Tobias Stadler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+package org.pitest.junit5.repository;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ *
+ * @author Tobias Stadler
+ */
+public class TestClassWithAbortingTest {
+    
+    @Test
+    public void test() {
+        assumeTrue(false);
+    }
+    
+}

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithFailingTest.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithFailingTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Tobias Stadler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+package org.pitest.junit5.repository;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ *
+ * @author Tobias Stadler
+ */
+public class TestClassWithFailingTest {
+    
+    @Test
+    public void test() {
+        assertTrue(false);
+    }
+    
+}


### PR DESCRIPTION
When assumptions from org.junit.jupiter.api.Assumptions throws TestAbortedException jUnit is considering such tests as skipped, but pit is marking such tests as failing