### PR TITLE
Add support for dynamic tests

### DIFF
--- a/src/main/java/org/pitest/junit5/AbstractTestExecutionListener.java
+++ b/src/main/java/org/pitest/junit5/AbstractTestExecutionListener.java
@@ -1,0 +1,37 @@
+package org.pitest.junit5;
+
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.reporting.ReportEntry;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.TestPlan;
+
+abstract class AbstractTestExecutionListener implements TestExecutionListener {
+    @Override
+    public void testPlanExecutionStarted(TestPlan testPlan) {
+    }
+
+    @Override
+    public void testPlanExecutionFinished(TestPlan testPlan) {
+    }
+
+    @Override
+    public void dynamicTestRegistered(TestIdentifier testIdentifier) {
+    }
+
+    @Override
+    public void executionSkipped(TestIdentifier testIdentifier, String reason) {
+    }
+
+    @Override
+    public void executionStarted(TestIdentifier testIdentifier) {
+    }
+
+    @Override
+    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+    }
+
+    @Override
+    public void reportingEntryPublished(TestIdentifier testIdentifier, ReportEntry entry) {
+    }
+}

--- a/src/main/java/org/pitest/junit5/JUnit5Configuration.java
+++ b/src/main/java/org/pitest/junit5/JUnit5Configuration.java
@@ -27,12 +27,18 @@ import org.pitest.testapi.TestUnitFinder;
  */
 public class JUnit5Configuration implements Configuration {
 
-    public JUnit5Configuration() {
+    private final boolean useDynamicTests;
+
+    public JUnit5Configuration(boolean useDynamicTests) {
+        this.useDynamicTests = useDynamicTests;
     }
 
     @Override
     public TestUnitFinder testUnitFinder() {
-        return new JUnit5TestUnitFinder();
+        if (useDynamicTests)
+            return new JUnit5DynamicTestUnitFinder();
+        else
+            return new JUnit5TestUnitFinder();
     }
 
     @Override

--- a/src/main/java/org/pitest/junit5/JUnit5DynamicTestUnitFinder.java
+++ b/src/main/java/org/pitest/junit5/JUnit5DynamicTestUnitFinder.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Tobias Stadler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+package org.pitest.junit5;
+
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.pitest.testapi.TestUnit;
+import org.pitest.testapi.TestUnitFinder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * @author Tobias Stadler
+ */
+public class JUnit5DynamicTestUnitFinder implements TestUnitFinder {
+
+    private final Launcher launcher;
+
+    public JUnit5DynamicTestUnitFinder() {
+        launcher = LauncherFactory.create();
+    }
+
+    @Override
+    public List<TestUnit> findTestUnits(Class<?> clazz) {
+        if (clazz.getEnclosingClass() != null)
+            return emptyList();
+
+        DynamicTestListener listener = new DynamicTestListener();
+        launcher.execute(LauncherDiscoveryRequestBuilder
+                .request()
+                .selectors(DiscoverySelectors.selectClass(clazz))
+                .build(), listener);
+
+        return listener.getIdentifiers()
+                .stream()
+                .map(testIdentifier -> new JUnit5TestUnit(clazz, testIdentifier))
+                .collect(Collectors.toList());
+    }
+
+    private class DynamicTestListener extends AbstractTestExecutionListener {
+        private final List<TestIdentifier> identifiers = new ArrayList<>();
+
+        List<TestIdentifier> getIdentifiers() {
+            return Collections.unmodifiableList(identifiers);
+        }
+
+        @Override
+        public void dynamicTestRegistered(TestIdentifier testIdentifier) {
+            final TestDescriptor.Type type = testIdentifier.getType();
+            if (type == TestDescriptor.Type.TEST || type == TestDescriptor.Type.CONTAINER_AND_TEST) {
+                identifiers.add(testIdentifier);
+            }
+        }
+    }
+}

--- a/src/main/java/org/pitest/junit5/JUnit5TestPluginFactory.java
+++ b/src/main/java/org/pitest/junit5/JUnit5TestPluginFactory.java
@@ -15,23 +15,24 @@
 package org.pitest.junit5;
 
 import java.util.Collection;
+
 import org.pitest.classinfo.ClassByteArraySource;
 import org.pitest.testapi.Configuration;
 import org.pitest.testapi.TestGroupConfig;
 import org.pitest.testapi.TestPluginFactory;
 
 /**
- *
  * @author Tobias Stadler
  */
 public class JUnit5TestPluginFactory implements TestPluginFactory {
 
     @Override
-    public Configuration createTestFrameworkConfiguration(TestGroupConfig config, 
-        ClassByteArraySource source, 
-        Collection<String> excludedRunners,
-        Collection<String> notYetSupported) {
-        return new JUnit5Configuration();
+    public Configuration createTestFrameworkConfiguration(
+            TestGroupConfig config,
+            ClassByteArraySource source,
+            Collection<String> excludedRunners,
+            Collection<String> notYetSupported) {
+        return new JUnit5Configuration(config.getIncludedGroups().contains("@dynamic-tests"));
     }
 
     @Override
@@ -41,7 +42,7 @@ public class JUnit5TestPluginFactory implements TestPluginFactory {
 
     @Override
     public String name() {
-      return "junit5";
+        return "junit5";
     }
 
 


### PR DESCRIPTION
Some modern test frameworks like KotlinTest, create their tests
dynamically and do not give anything besides the root TestDescriptor in
the TestPlan. For this reason, pitest completely fails to detect any
unit tests when used with recent versions of KotlinTest.

I've tried to fix it by adding a mode that detects dynamically
configured tests by executing the TestPlan and using a
TestExecutionListener to catch them.

Since there is no option to configure this mode with the current pitest
configuration, I'm checking if includedGroups contains the magic string
'@dynamic-tests' to determine whether to enable this mode.
That's quite ugly, but I can't think of a better way to configure that
besides writing an independent plugin for dynamic tests.