### PR TITLE
Adding junit-params to maven shade to enable Paramterized Junit5 tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,7 @@
 						<includes>
 							<include>org.junit.platform:*</include>
 							<include>org.junit.jupiter:junit-jupiter-engine</include>
+							<include>org.junit.jupiter:junit-jupiter-params </include>
 						</includes>
 					</artifactSet>
 				</configuration>


### PR DESCRIPTION
This is a fix for https://github.com/pitest/pitest-junit5-plugin/issues/24

This enables PITest to work on JUnit5 tests which have parameterized tests.