### PR TITLE
don't require a MethodSource when not filtering by className

### DIFF
--- a/src/main/java/org/pitest/junit5/JUnit5TestUnitFinder.java
+++ b/src/main/java/org/pitest/junit5/JUnit5TestUnitFinder.java
@@ -85,8 +85,10 @@ public class JUnit5TestUnitFinder implements TestUnitFinder {
                 .map(testPlan::getDescendants)
                 .flatMap(Set::stream)
                 .filter(testIdentifier -> {
-                    boolean isMethodSource = testIdentifier.getSource().isPresent() && testIdentifier.getSource().get() instanceof MethodSource;
-                    return (!testIdentifier.isContainer() || isMethodSource) && (includedTestMethods == null || includedTestMethods.isEmpty() || (isMethodSource &&
+                    boolean hasMethodSource = testIdentifier.getSource().isPresent() && testIdentifier.getSource().get() instanceof MethodSource;
+                    boolean isUnitTest = !testIdentifier.isContainer() || hasMethodSource;
+
+                    return isUnitTest && (includedTestMethods == null || includedTestMethods.isEmpty() || (hasMethodSource &&
                             includedTestMethods.contains(((MethodSource) testIdentifier.getSource().get()).getMethodName())));
                 })
                 .map(testIdentifier -> new JUnit5TestUnit(clazz, testIdentifier))

--- a/src/main/java/org/pitest/junit5/JUnit5TestUnitFinder.java
+++ b/src/main/java/org/pitest/junit5/JUnit5TestUnitFinder.java
@@ -84,8 +84,11 @@ public class JUnit5TestUnitFinder implements TestUnitFinder {
                 .stream()
                 .map(testPlan::getDescendants)
                 .flatMap(Set::stream)
-                .filter(testIdentifier -> testIdentifier.getSource().isPresent() && testIdentifier.getSource().get() instanceof MethodSource && (includedTestMethods == null || includedTestMethods.isEmpty()
-                        || includedTestMethods.contains(((MethodSource) testIdentifier.getSource().get()).getMethodName())))
+                .filter(testIdentifier -> {
+                    boolean isMethodSource = testIdentifier.getSource().isPresent() && testIdentifier.getSource().get() instanceof MethodSource;
+                    return (!testIdentifier.isContainer() || isMethodSource) && (includedTestMethods == null || includedTestMethods.isEmpty() || (isMethodSource &&
+                            includedTestMethods.contains(((MethodSource) testIdentifier.getSource().get()).getMethodName())));
+                })
                 .map(testIdentifier -> new JUnit5TestUnit(clazz, testIdentifier))
                 .collect(toList());
     }

--- a/src/main/java/org/pitest/junit5/JUnit5TestUnitFinder.java
+++ b/src/main/java/org/pitest/junit5/JUnit5TestUnitFinder.java
@@ -84,10 +84,8 @@ public class JUnit5TestUnitFinder implements TestUnitFinder {
                 .stream()
                 .map(testPlan::getDescendants)
                 .flatMap(Set::stream)
-                .filter(testIdentifier -> testIdentifier.getSource().isPresent())
-                .filter(testIdentifier -> testIdentifier.getSource().get() instanceof MethodSource)
-                .filter(testIdentifier -> includedTestMethods == null || includedTestMethods.isEmpty()
-                        || includedTestMethods.contains(((MethodSource) testIdentifier.getSource().get()).getMethodName()))
+                .filter(testIdentifier -> testIdentifier.getSource().isPresent() && testIdentifier.getSource().get() instanceof MethodSource && (includedTestMethods == null || includedTestMethods.isEmpty()
+                        || includedTestMethods.contains(((MethodSource) testIdentifier.getSource().get()).getMethodName())))
                 .map(testIdentifier -> new JUnit5TestUnit(clazz, testIdentifier))
                 .collect(toList());
     }


### PR DESCRIPTION
for better interopability with minutest. fixed #39 

I did not add a unit test for that case because it would probably require a mocking lib. 
