### PR TITLE
Correcting Gradle Quickstart in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ buildscript {
    }
    configurations.maybeCreate("pitest")
    dependencies {
-       classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.5.0'
-       pitest 'org.pitest:pitest-junit5-plugin:0.10-SNAPSHOT'
+       classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.4.5'
+       pitest 'org.pitest:pitest-junit5-plugin:0.10'
    }
 }
 


### PR DESCRIPTION
When I used the example Gradle buildscript, I noticed that 1.5.0 (the gradle-pitest-plugin version provided) wasn't available in Maven, and that the latest was 1.4.5:   https://mvnrepository.com/artifact/info.solidsoft.gradle.pitest/gradle-pitest-plugin

I also removed SNAPSHOT from the pitest-junit5-plugin version spec because it's no longer required, and pulling snapshot versions can require configuring special repositories in your buildscript.