### PR TITLE
Support non method based tests, for example with cucumber

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 		<junit.version>5.5.0</junit.version>
 		<mockito.version>2.7.6</mockito.version>
 		<pitest.version>1.4.10</pitest.version>
+		<cucumber.version>5.0.0-RC2</cucumber.version>
 	</properties>
 
 	<scm>
@@ -107,6 +108,18 @@
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>${assertj.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.cucumber</groupId>
+			<artifactId>cucumber-junit-platform-engine</artifactId>
+			<version>${cucumber.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.cucumber</groupId>
+			<artifactId>cucumber-java8</artifactId>
+			<version>${cucumber.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/org/pitest/junit5/JUnit5TestUnit.java
+++ b/src/main/java/org/pitest/junit5/JUnit5TestUnit.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.TestExecutionListener;
@@ -55,21 +56,26 @@ public class JUnit5TestUnit extends AbstractTestUnit {
             launcher.registerTestExecutionListeners(new TestExecutionListener() {
                 @Override
                 public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-                	if (testIdentifier.isTest()) {
+                    testIdentifier.getSource().ifPresent(testSource -> {
+                        if (testSource instanceof MethodSource) {
                             resultCollector.notifySkipped(new Description(testIdentifier.getDisplayName(), testClass));
-                    }
+                        }
+                    });
                 }
 
                 @Override
                 public void executionStarted(TestIdentifier testIdentifier) {
-                	if (testIdentifier.isTest()) {
+                    testIdentifier.getSource().ifPresent(testSource -> {
+                        if (testSource instanceof MethodSource) {
                             resultCollector.notifyStart(new Description(testIdentifier.getDisplayName(), testClass));
-                    }
+                        }
+                    });
                 }
 
                 @Override
                 public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-                	if (testIdentifier.isTest()) {
+                    testIdentifier.getSource().ifPresent(testSource -> {
+                        if (testSource instanceof MethodSource) {
                             Optional<Throwable> throwable = testExecutionResult.getThrowable();
 
                             if (TestExecutionResult.Status.ABORTED == testExecutionResult.getStatus()) {
@@ -81,7 +87,8 @@ public class JUnit5TestUnit extends AbstractTestUnit {
                             } else {
                                 resultCollector.notifyEnd(new Description(testIdentifier.getDisplayName(), testClass));
                             }
-                    }
+                        }
+                    });
                 }
 
             });

--- a/src/main/java/org/pitest/junit5/JUnit5TestUnit.java
+++ b/src/main/java/org/pitest/junit5/JUnit5TestUnit.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
-import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.TestExecutionListener;
@@ -56,26 +55,21 @@ public class JUnit5TestUnit extends AbstractTestUnit {
             launcher.registerTestExecutionListeners(new TestExecutionListener() {
                 @Override
                 public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-                    testIdentifier.getSource().ifPresent(testSource -> {
-                        if (testSource instanceof MethodSource) {
+                        if (testIdentifier.isTest()) {
                             resultCollector.notifySkipped(new Description(testIdentifier.getDisplayName(), testClass));
                         }
-                    });
                 }
 
                 @Override
                 public void executionStarted(TestIdentifier testIdentifier) {
-                    testIdentifier.getSource().ifPresent(testSource -> {
-                        if (testSource instanceof MethodSource) {
+                        if (testIdentifier.isTest()) {
                             resultCollector.notifyStart(new Description(testIdentifier.getDisplayName(), testClass));
                         }
-                    });
                 }
 
                 @Override
                 public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-                    testIdentifier.getSource().ifPresent(testSource -> {
-                        if (testSource instanceof MethodSource) {
+                        if (testIdentifier.isTest()) {
                             Optional<Throwable> throwable = testExecutionResult.getThrowable();
 
                             if (TestExecutionResult.Status.ABORTED == testExecutionResult.getStatus()) {
@@ -88,7 +82,6 @@ public class JUnit5TestUnit extends AbstractTestUnit {
                                 resultCollector.notifyEnd(new Description(testIdentifier.getDisplayName(), testClass));
                             }
                         }
-                    });
                 }
 
             });

--- a/src/main/java/org/pitest/junit5/JUnit5TestUnit.java
+++ b/src/main/java/org/pitest/junit5/JUnit5TestUnit.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
-import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.TestExecutionListener;
@@ -56,26 +55,21 @@ public class JUnit5TestUnit extends AbstractTestUnit {
             launcher.registerTestExecutionListeners(new TestExecutionListener() {
                 @Override
                 public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-                    testIdentifier.getSource().ifPresent(testSource -> {
-                        if (testSource instanceof MethodSource) {
+                	if (testIdentifier.isTest()) {
                             resultCollector.notifySkipped(new Description(testIdentifier.getDisplayName(), testClass));
-                        }
-                    });
+                    }
                 }
 
                 @Override
                 public void executionStarted(TestIdentifier testIdentifier) {
-                    testIdentifier.getSource().ifPresent(testSource -> {
-                        if (testSource instanceof MethodSource) {
+                	if (testIdentifier.isTest()) {
                             resultCollector.notifyStart(new Description(testIdentifier.getDisplayName(), testClass));
-                        }
-                    });
+                    }
                 }
 
                 @Override
                 public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-                    testIdentifier.getSource().ifPresent(testSource -> {
-                        if (testSource instanceof MethodSource) {
+                	if (testIdentifier.isTest()) {
                             Optional<Throwable> throwable = testExecutionResult.getThrowable();
 
                             if (TestExecutionResult.Status.ABORTED == testExecutionResult.getStatus()) {
@@ -87,8 +81,7 @@ public class JUnit5TestUnit extends AbstractTestUnit {
                             } else {
                                 resultCollector.notifyEnd(new Description(testIdentifier.getDisplayName(), testClass));
                             }
-                        }
-                    });
+                    }
                 }
 
             });

--- a/src/main/java/org/pitest/junit5/JUnit5TestUnitFinder.java
+++ b/src/main/java/org/pitest/junit5/JUnit5TestUnitFinder.java
@@ -17,9 +17,9 @@ package org.pitest.junit5;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
 
 import org.junit.platform.commons.util.PreconditionViolationException;
@@ -28,9 +28,10 @@ import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.TagFilter;
-import org.junit.platform.launcher.TestPlan;
+import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
 import org.pitest.testapi.TestGroupConfig;
 import org.pitest.testapi.TestUnit;
 import org.pitest.testapi.TestUnitFinder;
@@ -74,22 +75,39 @@ public class JUnit5TestUnitFinder implements TestUnitFinder {
             throw new IllegalArgumentException("Error creating tag filter", e);
         }
 
-        TestPlan testPlan = launcher.discover(LauncherDiscoveryRequestBuilder
+        TestIdentifierListener listener = new TestIdentifierListener();
+        launcher.execute(LauncherDiscoveryRequestBuilder
                 .request()
                 .selectors(DiscoverySelectors.selectClass(clazz))
                 .filters(filters.toArray(new Filter[filters.size()]))
-                .build());
+                .build(), listener);
 
-        return testPlan.getRoots()
+        return listener.getIdentifiers()
                 .stream()
-                .map(testPlan::getDescendants)
-                .flatMap(Set::stream)
-                .filter(testIdentifier -> testIdentifier.getSource().isPresent())
-                .filter(testIdentifier -> testIdentifier.getSource().get() instanceof MethodSource)
-                .filter(testIdentifier -> includedTestMethods == null || includedTestMethods.isEmpty()
-                        || includedTestMethods.contains(((MethodSource) testIdentifier.getSource().get()).getMethodName()))
                 .map(testIdentifier -> new JUnit5TestUnit(clazz, testIdentifier))
                 .collect(toList());
+    }
+
+    private class TestIdentifierListener extends SummaryGeneratingListener {
+		private final List<TestIdentifier> identifiers = new ArrayList<>();
+
+		List<TestIdentifier> getIdentifiers() {
+			return unmodifiableList(identifiers);
+		}
+
+		@Override
+		public void executionStarted(TestIdentifier testIdentifier) {
+			if (testIdentifier.isTest()) {
+				// filter out testMethods
+				if (includedTestMethods != null && !includedTestMethods.isEmpty()
+						&& testIdentifier.getSource().isPresent()
+						&& testIdentifier.getSource().get() instanceof MethodSource
+						&& !includedTestMethods.contains(((MethodSource)testIdentifier.getSource().get()).getMethodName())) {
+					return;
+				}
+ 				identifiers.add(testIdentifier);
+			}
+		}
     }
 
 }

--- a/src/main/java/org/pitest/junit5/JUnit5TestUnitFinder.java
+++ b/src/main/java/org/pitest/junit5/JUnit5TestUnitFinder.java
@@ -17,9 +17,9 @@ package org.pitest.junit5;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
 
 import org.junit.platform.commons.util.PreconditionViolationException;
@@ -28,10 +28,9 @@ import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.TagFilter;
-import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.TestPlan;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
-import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
 import org.pitest.testapi.TestGroupConfig;
 import org.pitest.testapi.TestUnit;
 import org.pitest.testapi.TestUnitFinder;
@@ -75,39 +74,22 @@ public class JUnit5TestUnitFinder implements TestUnitFinder {
             throw new IllegalArgumentException("Error creating tag filter", e);
         }
 
-		TestIdentifierCollector listener = new TestIdentifierCollector();
-		launcher.execute(LauncherDiscoveryRequestBuilder
+        TestPlan testPlan = launcher.discover(LauncherDiscoveryRequestBuilder
                 .request()
                 .selectors(DiscoverySelectors.selectClass(clazz))
                 .filters(filters.toArray(new Filter[filters.size()]))
-                .build(), listener);
+                .build());
 
-        return listener.getIdentifiers()
+        return testPlan.getRoots()
                 .stream()
+                .map(testPlan::getDescendants)
+                .flatMap(Set::stream)
+                .filter(testIdentifier -> testIdentifier.getSource().isPresent())
+                .filter(testIdentifier -> testIdentifier.getSource().get() instanceof MethodSource)
+                .filter(testIdentifier -> includedTestMethods == null || includedTestMethods.isEmpty()
+                        || includedTestMethods.contains(((MethodSource) testIdentifier.getSource().get()).getMethodName()))
                 .map(testIdentifier -> new JUnit5TestUnit(clazz, testIdentifier))
                 .collect(toList());
-    }
-
-	private class TestIdentifierCollector extends SummaryGeneratingListener {
-		private final List<TestIdentifier> identifiers = new ArrayList<>();
-
-		List<TestIdentifier> getIdentifiers() {
-			return unmodifiableList(identifiers);
-		}
-
-		@Override
-		public void executionStarted(TestIdentifier testIdentifier) {
-			if (testIdentifier.isTest()) {
-				// filter out testMethods
-				if (includedTestMethods != null && !includedTestMethods.isEmpty()
-						&& testIdentifier.getSource().isPresent()
-						&& testIdentifier.getSource().get() instanceof MethodSource
-						&& !includedTestMethods.contains(((MethodSource)testIdentifier.getSource().get()).getMethodName())) {
-					return;
-				}
- 				identifiers.add(testIdentifier);
-			}
-		}
     }
 
 }

--- a/src/test/java/org/pitest/junit5/JUnit5TestUnitFinderTest.java
+++ b/src/test/java/org/pitest/junit5/JUnit5TestUnitFinderTest.java
@@ -18,6 +18,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
+import org.pitest.junit5.cucumber.RunCucumberTest;
 import org.pitest.junit5.repository.TestClassWithIncludedTestMethod;
 import org.pitest.junit5.repository.TestClassWithInheritedTestMethod;
 import org.pitest.junit5.repository.TestClassWithNestedAnnotationAndNestedTestAnnotation;
@@ -129,4 +130,10 @@ public class JUnit5TestUnitFinderTest {
     public void testTestClassWithIncludedTag() {
         assertThat(new JUnit5TestUnitFinder(new TestGroupConfig().withIncludedGroups("included"), emptyList()).findTestUnits(TestClassWithTags.class)).hasSize(1);
     }
+
+    @Test
+    public void testRunCucumberTest() {
+        assertThat(new JUnit5TestUnitFinder(new TestGroupConfig(), emptyList()).findTestUnits(RunCucumberTest.class)).hasSize(1);
+    }
+
 }

--- a/src/test/java/org/pitest/junit5/cucumber/Glue.java
+++ b/src/test/java/org/pitest/junit5/cucumber/Glue.java
@@ -1,0 +1,16 @@
+package org.pitest.junit5.cucumber;
+
+import io.cucumber.java8.En;
+
+public class Glue implements En {
+
+	public Glue() {
+		Given("an initial step", () -> {
+		});
+		When("an action step", () -> {
+		});
+		Then("a check step", () -> {
+		});
+	}
+
+}

--- a/src/test/java/org/pitest/junit5/cucumber/RunCucumberTest.java
+++ b/src/test/java/org/pitest/junit5/cucumber/RunCucumberTest.java
@@ -1,0 +1,8 @@
+package org.pitest.junit5.cucumber;
+
+import io.cucumber.junit.platform.engine.Cucumber;
+
+@Cucumber
+public class RunCucumberTest {
+
+}

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithNestedAnnotationAndNestedTestFactoryAnnotation.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithNestedAnnotationAndNestedTestFactoryAnnotation.java
@@ -31,7 +31,7 @@ public class TestClassWithNestedAnnotationAndNestedTestFactoryAnnotation {
 
         @TestFactory
         public Collection<DynamicTest> testFactory() {
-    		return Collections.singleton(DynamicTest.dynamicTest("dynamic test", () -> {}));
+            return Collections.emptyList();
         }
 
     }

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithNestedAnnotationAndNestedTestFactoryAnnotation.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithNestedAnnotationAndNestedTestFactoryAnnotation.java
@@ -31,7 +31,7 @@ public class TestClassWithNestedAnnotationAndNestedTestFactoryAnnotation {
 
         @TestFactory
         public Collection<DynamicTest> testFactory() {
-            return Collections.emptyList();
+            return Collections.singleton(DynamicTest.dynamicTest("dynamic test", () -> {}));
         }
 
     }

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithNestedAnnotationAndNestedTestFactoryAnnotation.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithNestedAnnotationAndNestedTestFactoryAnnotation.java
@@ -31,7 +31,7 @@ public class TestClassWithNestedAnnotationAndNestedTestFactoryAnnotation {
 
         @TestFactory
         public Collection<DynamicTest> testFactory() {
-            return Collections.emptyList();
+    		return Collections.singleton(DynamicTest.dynamicTest("dynamic test", () -> {}));
         }
 
     }

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithNestedAnnotationWithNestedAnnotationAndNestedTestFactoryAnnotation.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithNestedAnnotationWithNestedAnnotationAndNestedTestFactoryAnnotation.java
@@ -34,7 +34,7 @@ public class TestClassWithNestedAnnotationWithNestedAnnotationAndNestedTestFacto
 
             @TestFactory
             public Collection<DynamicTest> testFactory() {
-        		return Collections.singleton(DynamicTest.dynamicTest("dynamic test", () -> {}));
+                return Collections.emptyList();
             }
 
         }

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithNestedAnnotationWithNestedAnnotationAndNestedTestFactoryAnnotation.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithNestedAnnotationWithNestedAnnotationAndNestedTestFactoryAnnotation.java
@@ -34,7 +34,7 @@ public class TestClassWithNestedAnnotationWithNestedAnnotationAndNestedTestFacto
 
             @TestFactory
             public Collection<DynamicTest> testFactory() {
-                return Collections.emptyList();
+        		return Collections.singleton(DynamicTest.dynamicTest("dynamic test", () -> {}));
             }
 
         }

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithNestedAnnotationWithNestedAnnotationAndNestedTestFactoryAnnotation.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithNestedAnnotationWithNestedAnnotationAndNestedTestFactoryAnnotation.java
@@ -34,7 +34,7 @@ public class TestClassWithNestedAnnotationWithNestedAnnotationAndNestedTestFacto
 
             @TestFactory
             public Collection<DynamicTest> testFactory() {
-                return Collections.emptyList();
+                return Collections.singleton(DynamicTest.dynamicTest("dynamic test", () -> {}));
             }
 
         }

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithTestFactoryAnnotation.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithTestFactoryAnnotation.java
@@ -27,7 +27,7 @@ public class TestClassWithTestFactoryAnnotation {
 
     @TestFactory
     public Collection<DynamicTest> testFactory() {
-        return Collections.emptyList();
+		return Collections.singleton(DynamicTest.dynamicTest("dynamic test", () -> {}));
     }
 
 }

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithTestFactoryAnnotation.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithTestFactoryAnnotation.java
@@ -27,7 +27,7 @@ public class TestClassWithTestFactoryAnnotation {
 
     @TestFactory
     public Collection<DynamicTest> testFactory() {
-		return Collections.singleton(DynamicTest.dynamicTest("dynamic test", () -> {}));
+        return Collections.emptyList();
     }
 
 }

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithTestFactoryAnnotation.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithTestFactoryAnnotation.java
@@ -27,7 +27,7 @@ public class TestClassWithTestFactoryAnnotation {
 
     @TestFactory
     public Collection<DynamicTest> testFactory() {
-        return Collections.emptyList();
+        return Collections.singleton(DynamicTest.dynamicTest("dynamic test", () -> {}));
     }
 
 }

--- a/src/test/resources/org/pitest/junit5/cucumber/pitest-junit5-cucumber.feature
+++ b/src/test/resources/org/pitest/junit5/cucumber/pitest-junit5-cucumber.feature
@@ -1,0 +1,6 @@
+Feature: pitest-junit5-cucumber
+
+  Scenario: a cucumber scenario is found
+    Given an initial step
+    When an action step
+    Then a check step


### PR DESCRIPTION
Cucumber JUnit Platform Engine (https://github.com/cucumber/cucumber-jvm/tree/master/junit-platform-engine) defines tests from Gherkin .feature files, not class and methods.

Builds on:
- https://github.com/pitest/pitest-junit5-plugin/pull/41 generalized to filtering on testIdentifier.isTest()
- https://github.com/pitest/pitest-junit5-plugin/pull/22 generalized to all cases as dynamic tests factory methods are typed CONTAINER not TEST

Dynamic tests factory methods are modified to actually dynamically define one test.

Using this version of pitest-junit5-plugin and cucumber-junit-platform-engine allow seamless integration of both pitest and cucumber through junit-platform