### PR TITLE
Fix JUnit5 test execution after discovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.pitest</groupId>
 	<artifactId>pitest-junit5-plugin</artifactId>
-	<version>0.13-SNAPSHOT</version>
+	<version>0.13.0-SNAPSHOT</version>
         
 	<name>pitest-junit5-plugin</name>
 	<url>http://pitest.org</url>

--- a/src/main/java/org/pitest/junit5/JUnit5TestUnit.java
+++ b/src/main/java/org/pitest/junit5/JUnit5TestUnit.java
@@ -45,11 +45,16 @@ public class JUnit5TestUnit extends AbstractTestUnit {
     public void execute(ResultCollector resultCollector) {
         Launcher launcher = LauncherFactory.create();
         UniqueId uniqueId = UniqueId.parse(testIdentifier.getUniqueId());
+        Optional<UniqueId> parentIdOptional = testIdentifier.getParentId().map(UniqueId::parse);
         LauncherDiscoveryRequest launcherDiscoveryRequest = LauncherDiscoveryRequestBuilder
                 .request()
                 .selectors(DiscoverySelectors.selectUniqueId(uniqueId))
                 .filters((PostDiscoveryFilter) testDescriptor -> FilterResult.includedIf(
-                        uniqueId.equals(testDescriptor.getUniqueId())))
+                        uniqueId.equals(testDescriptor.getUniqueId()) ||
+                                testDescriptor.mayRegisterTests() &&
+                                        parentIdOptional
+                                                .map(testDescriptor.getUniqueId()::equals)
+                                                .orElse(false)))
                 .build();
 
             launcher.registerTestExecutionListeners(new TestExecutionListener() {

--- a/src/main/java/org/pitest/junit5/JUnit5TestUnit.java
+++ b/src/main/java/org/pitest/junit5/JUnit5TestUnit.java
@@ -16,12 +16,9 @@ package org.pitest.junit5;
 
 import java.util.Optional;
 
-import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.*;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
-import org.junit.platform.launcher.Launcher;
-import org.junit.platform.launcher.LauncherDiscoveryRequest;
-import org.junit.platform.launcher.TestExecutionListener;
-import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.*;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 import org.pitest.testapi.AbstractTestUnit;
@@ -47,9 +44,12 @@ public class JUnit5TestUnit extends AbstractTestUnit {
     @Override
     public void execute(ResultCollector resultCollector) {
         Launcher launcher = LauncherFactory.create();
+        UniqueId uniqueId = UniqueId.parse(testIdentifier.getUniqueId());
         LauncherDiscoveryRequest launcherDiscoveryRequest = LauncherDiscoveryRequestBuilder
                 .request()
-                .selectors(DiscoverySelectors.selectUniqueId(testIdentifier.getUniqueId()))
+                .selectors(DiscoverySelectors.selectUniqueId(uniqueId))
+                .filters((PostDiscoveryFilter) testDescriptor -> FilterResult.includedIf(
+                        uniqueId.equals(testDescriptor.getUniqueId())))
                 .build();
 
             launcher.registerTestExecutionListeners(new TestExecutionListener() {

--- a/src/test/java/org/pitest/junit5/JUnit5TestUnitTest.java
+++ b/src/test/java/org/pitest/junit5/JUnit5TestUnitTest.java
@@ -131,14 +131,13 @@ public class JUnit5TestUnitTest {
         assertThat(resultCollector.getEnded()).hasSize(1);
         assertThat(resultCollector.getFailure()).isEmpty();
     }
-    
-    private TestResultCollector findTestsIn(Class<?> clazz) {
-      TestResultCollector resultCollector = new TestResultCollector();
-      Stream<TestUnit> stream = new JUnit5TestUnitFinder(new TestGroupConfig(), emptyList()).findTestUnits(clazz)
-      .stream();
 
-      stream.forEach(testUnit -> testUnit.execute(resultCollector));
-      return resultCollector;
+    private TestResultCollector findTestsIn(Class<?> clazz) {
+        TestResultCollector resultCollector = new TestResultCollector();
+        new JUnit5TestUnitFinder(new TestGroupConfig(), emptyList()).findTestUnits(clazz)
+                .stream()
+                .forEach(testUnit -> testUnit.execute(resultCollector));
+        return resultCollector;
     }
 
     private static class TestResultCollector implements ResultCollector {

--- a/src/test/java/org/pitest/junit5/JUnit5TestUnitTest.java
+++ b/src/test/java/org/pitest/junit5/JUnit5TestUnitTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.pitest.junit5.repository.TestClassWithAbortingTest;
@@ -34,6 +35,7 @@ import org.pitest.junit5.repository.TestClassWithTestFactoryAnnotation;
 import org.pitest.testapi.Description;
 import org.pitest.testapi.ResultCollector;
 import org.pitest.testapi.TestGroupConfig;
+import org.pitest.testapi.TestUnit;
 
 /**
  *
@@ -132,9 +134,10 @@ public class JUnit5TestUnitTest {
     
     private TestResultCollector findTestsIn(Class<?> clazz) {
       TestResultCollector resultCollector = new TestResultCollector();
-      new JUnit5TestUnitFinder(new TestGroupConfig(), emptyList()).findTestUnits(clazz)
-      .stream()
-      .forEach(testUnit -> testUnit.execute(resultCollector));
+      Stream<TestUnit> stream = new JUnit5TestUnitFinder(new TestGroupConfig(), emptyList()).findTestUnits(clazz)
+      .stream();
+
+      stream.forEach(testUnit -> testUnit.execute(resultCollector));
       return resultCollector;
     }
 

--- a/src/test/java/org/pitest/junit5/JUnit5TestUnitTest.java
+++ b/src/test/java/org/pitest/junit5/JUnit5TestUnitTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.pitest.junit5.repository.TestClassWithAbortingTest;
@@ -35,7 +34,6 @@ import org.pitest.junit5.repository.TestClassWithTestFactoryAnnotation;
 import org.pitest.testapi.Description;
 import org.pitest.testapi.ResultCollector;
 import org.pitest.testapi.TestGroupConfig;
-import org.pitest.testapi.TestUnit;
 
 /**
  *
@@ -131,13 +129,13 @@ public class JUnit5TestUnitTest {
         assertThat(resultCollector.getEnded()).hasSize(1);
         assertThat(resultCollector.getFailure()).isEmpty();
     }
-
+    
     private TestResultCollector findTestsIn(Class<?> clazz) {
-        TestResultCollector resultCollector = new TestResultCollector();
-        new JUnit5TestUnitFinder(new TestGroupConfig(), emptyList()).findTestUnits(clazz)
-                .stream()
-                .forEach(testUnit -> testUnit.execute(resultCollector));
-        return resultCollector;
+      TestResultCollector resultCollector = new TestResultCollector();
+      new JUnit5TestUnitFinder(new TestGroupConfig(), emptyList()).findTestUnits(clazz)
+      .stream()
+      .forEach(testUnit -> testUnit.execute(resultCollector));
+      return resultCollector;
     }
 
     private static class TestResultCollector implements ResultCollector {


### PR DESCRIPTION
JUnitTestFinder is obtaining the correct tests from the project and assigning a correct uniqueid to each test. After this when this unit test is executed (JUnit5TestUnit#execute) the LauncherDiscoveryRequest is executed once again with a selector for the uniqueid in order do identity the test. This is ok, but not enough and gives wrong results specially when we have different test engines (junit5, kotest, ...) running. With this approach and after seeing the internal implementation when we are executing, a test plan is made including all engines and it is picking up everything for every engine including unrelated tests.

In order to solve this we have to prune this unrelated tests by applying a post filter. The effect of this is to remove all unrelated engines and tests from the Hierarchy within the test plan.

Also in this commit I've updated the version to follow the semver standard approach c.f. https://semver.org/