### PR TITLE
Update JUnit to 5.7.0 and JUnit Platform to 1.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.pitest</groupId>
 	<artifactId>pitest-junit5-plugin</artifactId>
-	<version>0.13-SNAPSHOT</version>
+	<version>0.13.3-SNAPSHOT</version>
         
 	<name>pitest-junit5-plugin</name>
 	<url>http://pitest.org</url>
@@ -17,8 +17,8 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<assertj.version>3.14.0</assertj.version>
-		<junit.platform.version>1.6.0</junit.platform.version>
-		<junit.version>5.6.1</junit.version>
+		<junit.platform.version>1.7.0</junit.platform.version>
+		<junit.version>5.7.0</junit.version>
 		<mockito.version>2.7.6</mockito.version>
 		<pitest.version>1.4.11</pitest.version>
 		<cucumber.version>5.0.0</cucumber.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.pitest</groupId>
 	<artifactId>pitest-junit5-plugin</artifactId>
-	<version>0.13.3-SNAPSHOT</version>
+	<version>0.13-SNAPSHOT</version>
         
 	<name>pitest-junit5-plugin</name>
 	<url>http://pitest.org</url>


### PR DESCRIPTION
Updating the following dependencies to their current latest versions:

```
org.junit.platform:junit-platform-launcher -> 1.7.0
org.junit.jupiter:junit-jupiter -> 5.7.0
```

I believe that this also addresses issue #54 due to a mismatch in how later versions of the JUnit Platform Launcher are identifying parameterized tests.

I've built this locally on JDK8 and JDK11 and all the tests pass. I've also used it locally in a project and it seems fine.