### PR TITLE
support failing BeforeAlls

### DIFF
--- a/src/main/java/org/pitest/junit5/JUnit5TestUnit.java
+++ b/src/main/java/org/pitest/junit5/JUnit5TestUnit.java
@@ -69,9 +69,8 @@ public class JUnit5TestUnit extends AbstractTestUnit {
 
                 @Override
                 public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+                    Optional<Throwable> throwable = testExecutionResult.getThrowable();
                         if (testIdentifier.isTest()) {
-                            Optional<Throwable> throwable = testExecutionResult.getThrowable();
-
                             if (TestExecutionResult.Status.ABORTED == testExecutionResult.getStatus()) {
                                 // abort treated as success
                                 // see: https://junit.org/junit5/docs/5.0.0/api/org/junit/jupiter/api/Assumptions.html
@@ -80,6 +79,11 @@ public class JUnit5TestUnit extends AbstractTestUnit {
                                 resultCollector.notifyEnd(new Description(testIdentifier.getUniqueId(), testClass), throwable.get());
                             } else {
                                 resultCollector.notifyEnd(new Description(testIdentifier.getUniqueId(), testClass));
+                            }
+                        } else {
+                            // Classes with failing BeforeAll methods identify as containers, not tests.
+                            if (throwable.isPresent()) {
+                                resultCollector.notifyEnd(new Description(testIdentifier.getUniqueId(), testClass), throwable.get());
                             }
                         }
                 }

--- a/src/main/java/org/pitest/junit5/JUnit5TestUnitFinder.java
+++ b/src/main/java/org/pitest/junit5/JUnit5TestUnitFinder.java
@@ -24,7 +24,9 @@ import static java.util.stream.Collectors.toList;
 
 import org.junit.platform.commons.util.PreconditionViolationException;
 import org.junit.platform.engine.Filter;
+import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.TagFilter;
@@ -108,6 +110,18 @@ public class JUnit5TestUnitFinder implements TestUnitFinder {
  				identifiers.add(testIdentifier);
 			}
 		}
+
+
+        @Override
+        public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+            // Classes with failing BeforeAlls never start execution and identify as 'containers' not 'tests'
+            if (testExecutionResult.getStatus() == TestExecutionResult.Status.FAILED) {
+                if (!identifiers.contains(testIdentifier)) {
+                    identifiers.add(testIdentifier);
+                }
+            }
+        }
+
     }
 
 }

--- a/src/test/java/org/pitest/junit5/JUnit5TestUnitTest.java
+++ b/src/test/java/org/pitest/junit5/JUnit5TestUnitTest.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.pitest.junit5.repository.TestClassWithAbortingTest;
+import org.pitest.junit5.repository.TestClassWithBeforeAll;
+import org.pitest.junit5.repository.TestClassWithFailingBeforeAll;
 import org.pitest.junit5.repository.TestClassWithFailingTest;
 import org.pitest.junit5.repository.TestClassWithInheritedTestMethod;
 import org.pitest.junit5.repository.TestClassWithNestedAnnotationAndNestedTestAnnotation;
@@ -39,10 +41,10 @@ import org.pitest.testapi.TestGroupConfig;
  *
  * @author tobias
  */
-public class JUnit5TestUnitTest {
+class JUnit5TestUnitTest {
 
     @Test
-    public void testTestClassWithTestAnnotation() {
+    void testTestClassWithTestAnnotation() {
         TestResultCollector resultCollector = findTestsIn(TestClassWithTestAnnotation.class);
 
         assertThat(resultCollector.getSkipped()).isEmpty();
@@ -51,7 +53,7 @@ public class JUnit5TestUnitTest {
     }
 
     @Test
-    public void test3TestClassWithTestFactoryAnnotation() {
+    void test3TestClassWithTestFactoryAnnotation() {
         TestResultCollector resultCollector = findTestsIn(TestClassWithTestFactoryAnnotation.class);
 
         assertThat(resultCollector.getSkipped()).isEmpty();
@@ -60,7 +62,7 @@ public class JUnit5TestUnitTest {
     }
 
     @Test
-    public void testTestClassWithNestedAnnotationAndNestedTestAnnotation() {
+    void testTestClassWithNestedAnnotationAndNestedTestAnnotation() {
         TestResultCollector resultCollector = 
         findTestsIn(TestClassWithNestedAnnotationAndNestedTestAnnotation.class);
 
@@ -71,7 +73,7 @@ public class JUnit5TestUnitTest {
 
 
     @Test
-    public void testTestClassWithNestedAnnotationAndNestedTestFactoryAnnotation() {
+    void testTestClassWithNestedAnnotationAndNestedTestFactoryAnnotation() {
         TestResultCollector resultCollector =
         findTestsIn(TestClassWithNestedAnnotationAndNestedTestFactoryAnnotation.class);
 
@@ -81,7 +83,7 @@ public class JUnit5TestUnitTest {
     }
 
     @Test
-    public void testTestClassWithNestedAnnotationWithNestedAnnotationAndNestedTestAnnotation() {
+    void testTestClassWithNestedAnnotationWithNestedAnnotationAndNestedTestAnnotation() {
         TestResultCollector resultCollector = 
         findTestsIn(TestClassWithNestedAnnotationWithNestedAnnotationAndNestedTestAnnotation.class);
      
@@ -91,7 +93,7 @@ public class JUnit5TestUnitTest {
     }
 
     @Test
-    public void testTestClassWithNestedAnnotationWithNestedAnnotationAndNestedTestFactoryAnnotation() {
+    void testTestClassWithNestedAnnotationWithNestedAnnotationAndNestedTestFactoryAnnotation() {
         TestResultCollector resultCollector = 
         findTestsIn(TestClassWithNestedAnnotationWithNestedAnnotationAndNestedTestFactoryAnnotation.class);
 
@@ -101,7 +103,7 @@ public class JUnit5TestUnitTest {
     }
 
     @Test
-    public void testTestClassWithInheritedTestMethod() {
+    void testTestClassWithInheritedTestMethod() {
         TestResultCollector resultCollector =
         findTestsIn(TestClassWithInheritedTestMethod.class);
 
@@ -111,7 +113,7 @@ public class JUnit5TestUnitTest {
     }
 
     @Test
-    public void testTestClassWithFailingTest() {
+    void testTestClassWithFailingTest() {
         TestResultCollector resultCollector = findTestsIn(TestClassWithFailingTest.class);
 
         assertThat(resultCollector.getSkipped()).isEmpty();
@@ -121,7 +123,7 @@ public class JUnit5TestUnitTest {
     }
 
     @Test
-    public void testTestClassWithAbortingTest() {
+    void testTestClassWithAbortingTest() {
         TestResultCollector resultCollector = findTestsIn(TestClassWithAbortingTest.class);
 
         assertThat(resultCollector.getSkipped()).isEmpty();
@@ -129,6 +131,25 @@ public class JUnit5TestUnitTest {
         assertThat(resultCollector.getEnded()).hasSize(1);
         assertThat(resultCollector.getFailure()).isEmpty();
     }
+
+    @Test
+    void testRunsBeforeAlls() {
+        TestResultCollector resultCollector = findTestsIn(TestClassWithBeforeAll.class);
+
+        assertThat(resultCollector.getSkipped()).isEmpty();
+        assertThat(resultCollector.getStarted()).hasSize(2);
+        assertThat(resultCollector.getFailure()).isEmpty();
+    }
+
+    @Test
+    void testFailsWhenBeforeAllFails() {
+        TestResultCollector resultCollector = findTestsIn(TestClassWithFailingBeforeAll.class);
+
+        assertThat(resultCollector.getSkipped()).isEmpty();
+        assertThat(resultCollector.getStarted()).hasSize(0);
+        assertThat(resultCollector.getFailure()).isPresent();
+    }
+
     
     private TestResultCollector findTestsIn(Class<?> clazz) {
       TestResultCollector resultCollector = new TestResultCollector();

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithBeforeAll.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithBeforeAll.java
@@ -1,0 +1,29 @@
+package org.pitest.junit5.repository;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestClassWithBeforeAll {
+    static boolean fail = true;
+
+    @BeforeAll
+    static void fails() {
+        fail = false;
+    }
+
+    @Test
+    void aTest() {
+        if (fail) {
+            fail();
+        }
+    }
+
+    @Test
+    void anotherTest() {
+        if (fail) {
+            fail();
+        }
+    }
+}

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithFailingBeforeAll.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithFailingBeforeAll.java
@@ -1,0 +1,25 @@
+package org.pitest.junit5.repository;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestClassWithFailingBeforeAll {
+
+    @BeforeAll
+    static void fails() {
+        fail();
+    }
+
+    @Test
+    void aTest() {
+
+    }
+
+    @Test
+    void anotherTest() {
+
+    }
+
+}


### PR DESCRIPTION
Fix for #64

When a BeforeAll fails, jupiter generates a container, which never
registers as starting. Other engines may do something similar. To work
around this, and failing test identifier is now recorded even if it does
not identify as a test.

These failing units will still not appear to start, which may have
consequences that need to be examined.
