### PR TITLE
update for pitest 1.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,10 +20,10 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<assertj.version>3.14.0</assertj.version>
-		<junit.platform.version>1.8.0</junit.platform.version>
-		<junit.version>5.8.0</junit.version>
+		<junit.platform.version>1.8.2</junit.platform.version>
+		<junit.version>5.8.2</junit.version>
 		<mockito.version>2.7.6</mockito.version>
-		<pitest.version>1.4.11</pitest.version>
+		<pitest.version>1.9.0</pitest.version>
 		<cucumber.version>5.0.0</cucumber.version>
 	</properties>
 

--- a/src/main/java/org/pitest/junit5/JUnit5TestUnit.java
+++ b/src/main/java/org/pitest/junit5/JUnit5TestUnit.java
@@ -26,13 +26,14 @@ import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 import org.pitest.testapi.AbstractTestUnit;
 import org.pitest.testapi.Description;
+import org.pitest.testapi.ExecutedInDiscovery;
 import org.pitest.testapi.ResultCollector;
 
 /**
  *
  * @author Tobias Stadler
  */
-public class JUnit5TestUnit extends AbstractTestUnit {
+public class JUnit5TestUnit extends AbstractTestUnit implements ExecutedInDiscovery {
 
     private final Class<?> testClass;
 
@@ -92,4 +93,9 @@ public class JUnit5TestUnit extends AbstractTestUnit {
             launcher.execute(launcherDiscoveryRequest);
     }
 
+
+    @Override
+    public String toString() {
+        return "JUnit5TestUnit[" + testIdentifier.getUniqueId() + "]";
+    }
 }

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithAfterAll.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithAfterAll.java
@@ -1,0 +1,22 @@
+package org.pitest.junit5.repository;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+public class TestClassWithAfterAll {
+
+    @AfterAll
+    static void hello() {
+
+    }
+
+    @Test
+    void aTest() {
+
+    }
+
+    @Test
+    void anotherTest() {
+
+    }
+}

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithFailingAfterAll.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithFailingAfterAll.java
@@ -1,0 +1,24 @@
+package org.pitest.junit5.repository;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestClassWithFailingAfterAll {
+
+    @AfterAll
+    static void oops() {
+      fail();
+    }
+
+    @Test
+    void aTest() {
+
+    }
+
+    @Test
+    void anotherTest() {
+
+    }
+}

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithMixedPassAndFail.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithMixedPassAndFail.java
@@ -1,0 +1,28 @@
+package org.pitest.junit5.repository;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestClassWithMixedPassAndFail {
+
+    @Test
+    void passingTest() {
+
+    }
+
+    @Test
+    void passingTest2() {
+
+    }
+
+    @Test
+    void failingTest() {
+        fail();
+    }
+
+    @Test
+    void erroringTest() {
+        throw new RuntimeException();
+    }
+}

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithMultiplePassingTests.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithMultiplePassingTests.java
@@ -1,0 +1,21 @@
+package org.pitest.junit5.repository;
+
+import org.junit.jupiter.api.Test;
+
+public class TestClassWithMultiplePassingTests {
+
+    @Test
+    void testOne() {
+
+    }
+
+    @Test
+    void testTwo() {
+
+    }
+
+    @Test
+    void testThree() {
+
+    }
+}


### PR DESCRIPTION
Pitest 1.9.0 adds support for test plugins where the discovery
and execution of tests is not seperated (ie JUnit 5).

Previously each JUnit 5 test was executed twice during the coverage
stage, once to discover it, then again to run it for real.

This change takes advantage of the interfaces modified in 1.9.0 to
ensure that JUnit 5 tests are now discovered and run with one execution.