### PR TITLE
Build with JUnit Platform 1.9.1 to support JUnit Jupiter 5.9.1 #69

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<assertj.version>3.14.0</assertj.version>
-		<junit.platform.version>1.8.2</junit.platform.version>
+		<junit.platform.version>1.9.1</junit.platform.version>
 		<junit.version>5.8.2</junit.version>
 		<mockito.version>2.7.6</mockito.version>
 		<pitest.version>1.9.0</pitest.version>

--- a/src/test/java/org/pitest/junit5/JUnit5TestUnitFinderTest.java
+++ b/src/test/java/org/pitest/junit5/JUnit5TestUnitFinderTest.java
@@ -100,7 +100,7 @@ class JUnit5TestUnitFinderTest {
 
     @Test
     void findsAndRunsParameterizedTests() {
-        findsAndRunsNTests(1, TestClassWithParameterizedTestAnnotation.class);
+        findsAndRunsNTests(2, TestClassWithParameterizedTestAnnotation.class);
     }
 
     @Test

--- a/src/test/java/org/pitest/junit5/repository/TestClassWithParameterizedTestAnnotation.java
+++ b/src/test/java/org/pitest/junit5/repository/TestClassWithParameterizedTestAnnotation.java
@@ -14,7 +14,10 @@
  */
 package org.pitest.junit5.repository;
 
+import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
@@ -22,11 +25,20 @@ import org.junit.jupiter.params.provider.ValueSource;
  * @author Tobias Stadler
  */
 public class TestClassWithParameterizedTestAnnotation {
-    
+
     @ParameterizedTest
     @ValueSource(strings = {"foo"})
     public void parameterizedTest(String string) {
         
     }
-    
+
+    @ParameterizedTest
+    @MethodSource("someMethod")
+    public void methodParameterizedTest(String string) {
+
+    }
+
+    static Stream<Arguments> someMethod() {
+        return Stream.of(Arguments.of("foo"));
+    }
 }


### PR DESCRIPTION
By bundling the shaded 1.9.1 version of JUnit Platform, it addresses issues finding the method org.junit.platform.commons.util.CollectionUtils.isConvertibleToStream which is required by JUnit Jupiter 5.9.1. The JUnit Platform is backwards compatible with older versions of Jupiter, at least back to 5.8.2.