### PR TITLE
Remove unnecessary exclusion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,12 +142,6 @@
 			<groupId>org.pitest</groupId>
 			<artifactId>pitest</artifactId>
 			<version>${pitest.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>junit</groupId>
-					<artifactId>junit</artifactId>
-				</exclusion>
-			</exclusions>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Since pitest 1.3.0 junit:junit is just a provided dependency,
so excluding it explicitly is obsolete.