### PR TITLE
Remove shaded JUnit platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Adds support to pitest for JUnit 5 platform test engines, e.g. Jupiter, Cucumber
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.pitest/pitest-junit5-plugin/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/org.pitest/pitest-junit5-plugin)
 
+* 1.2.0 requires pitest 1.14.0 or above and JUnit Platform 1.9.2 (Jupiter 5.9.2)
 * 1.1.2 requires pitest 1.9.0 or above and JUnit Platform 1.9.2 (Jupiter 5.9.2)
 * 1.1.1 requires pitest 1.9.0 or above and JUnit Platform 1.9.1 (Jupiter 5.9.1)
 * 1.1.0 requires pitest 1.9.0 or above and JUnit Platform 1.9.1 (Jupiter 5.9.1)

--- a/pom.xml
+++ b/pom.xml
@@ -249,25 +249,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.2.1</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<artifactSet>
-						<includes>
-							<include>org.junit.platform:*</include>
-						</includes>
-					</artifactSet>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>flatten-maven-plugin</artifactId>
 				<version>1.2.5</version>


### PR DESCRIPTION
It is present as dependency anyway and even if not it makes no sense to depend on
this module without platform being present already anywy and shading it without relocation easily leads to conflicts.