### PR TITLE
Mark the junit-platform-launcher dependency as provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>
 			<version>${junit.platform.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
For version 2.0.0 of the plugin.

Integrations like the Maven plugin or Gradle plugin are supposed to add this
dependency in the correct version that is also used for the remaining platform artifacts
on the SUT classpath