### PR TITLE
Log test failures and errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<junit.platform.version>1.9.2</junit.platform.version>
 		<junit.version>5.9.2</junit.version>
 		<mockito.version>2.7.6</mockito.version>
-		<pitest.version>1.9.0</pitest.version>
+		<pitest.version>1.15.2</pitest.version>
 		<cucumber.version>5.0.0</cucumber.version>
 		<spock.version>2.3-groovy-4.0</spock.version>
 		<groovy.version>4.0.11</groovy.version>
@@ -238,7 +238,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.5</version>
+				<version>0.8.11</version>
 				<executions>
 					<execution>
 						<goals>

--- a/src/main/java/org/pitest/junit5/JUnit5TestUnitFinder.java
+++ b/src/main/java/org/pitest/junit5/JUnit5TestUnitFinder.java
@@ -130,9 +130,11 @@ public class JUnit5TestUnitFinder implements TestUnitFinder {
                 if (!identifiers.contains(testIdentifier)) {
                     identifiers.add(testIdentifier);
                 }
-                l.executionFinished(new Description(testIdentifier.getUniqueId(), testClass), false);
+                l.executionFinished(new Description(testIdentifier.getUniqueId(), testClass)
+                        , false, testExecutionResult.getThrowable().orElse(null));
             } else if (testIdentifier.isTest()) {
-                l.executionFinished(new Description(testIdentifier.getUniqueId(), testClass), true);
+                l.executionFinished(new Description(testIdentifier.getUniqueId(), testClass)
+                        , true);
             }
         }
 


### PR DESCRIPTION
Tests run during discovery in the coverage phase did not report the exceptions if they errored or failed. Pitest 1.15.2 now allows this information to be passed on for logging.