### PR TITLE
set junit-platform-launcher to provided scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>
 			<version>${junit.platform.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Platform-launcher was being included as a transitive dependency of the plugin. This caused conflicts with correct version of launcher auto-downloaded by the maven plugin. For some reason this only reliably manifested as an issue with the release of platform 1.12.0.